### PR TITLE
Numeric subfields weren't allowed

### DIFF
--- a/src/org/solrmarc/index/indexer/FullScanner.lex
+++ b/src/org/solrmarc/index/indexer/FullScanner.lex
@@ -152,7 +152,7 @@ datespec = "date"|[Dd]"ateOfPublication"|[Dd]"ateRecordIndexed"|"index_date"
 
 <SUBFIELDSPEC>{
 "[""^"?[a-z][-a-z0-9]*"]"   { return symbol("SUBFIELDSPEC",FullSym.SUBFIELDSPEC, yytext()); }
-[a-z][a-z0-9]*              { return symbol("SUBFIELDSPEC",FullSym.SUBFIELDSPEC, yytext()); }
+[a-z0-9]+                   { return symbol("SUBFIELDSPEC",FullSym.SUBFIELDSPEC, yytext()); }
 "["[0-9]+(-[0-9]+)?"]"      { return symbol("POSITION", FullSym.POSITION, yytext()); }
 {white_space}               { /* ignore */ }
 ":"						    { yybegin(YYINITIAL);   return symbol(":",FullSym.COLON);  }


### PR DESCRIPTION
currently we are upgrading to the new solrmarc. We are trying to extract subfield 0 (zero) of field 100 and encountered following problem:

    ERROR [main] (IndexDriver.java:328) - pndnum =  1000
    ERROR [main] (IndexDriver.java:330) - pndnum : Error: Illegal character <0>  found in scanner state subfield

This simple change fixed this problem. Probably the line above needs this fix as well.